### PR TITLE
Updated launch.sh to handle Mac & /tmp/ mounting better

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,10 @@ services:
                 condition: service_healthy
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8082/health"]
+            interval: 10s
+            timeout: 10s
+            retries: 5
+            start_period: 30s
         working_dir: /app/api
         command:
             ./dev.sh
@@ -61,7 +65,7 @@ services:
         networks:
             - ezbids
         tty: true #turn on color for bids-validator output
-        command: pm2 start handler.js --attach --watch --ignore-watch "ui **/node_modules"
+        command: pm2 start handler.js --attach --watch --ignore-watch "ui **/node_modules **__pycache__**"
 
     ui:
         container_name: brainlife_ezbids-ui
@@ -70,8 +74,16 @@ services:
         environment:
             VITE_APIHOST: http://${SERVER_NAME:-localhost}:8082
             VITE_BRAINLIFE_AUTHENTICATION: ${BRAINLIFE_AUTHENTICATION:-false}
+        depends_on:
+            - api
+            - mongodb
+            - handler
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:3000"]
+            interval: 10s
+            timeout: 10s
+            retries: 5
+            start_period: 30s
         ports:
             - 3000:3000 #vite wants to be exposed on the host for HMR?
         networks:

--- a/handler/handler.js
+++ b/handler/handler.js
@@ -47,7 +47,7 @@ function run() {
             }
         }
         console.log("waiting a bit before looking for more jobs");
-        setTimeout(run, 1000 * 3);
+        setTimeout(run, 1000 * 1);
     }));
 }
 function handle_uploaded(session) {

--- a/handler/handler.ts
+++ b/handler/handler.ts
@@ -1,4 +1,3 @@
-
 const { spawn } = require('child_process');
 import fs = require('fs');
 
@@ -40,7 +39,7 @@ function run() {
             }
         }
         console.log("waiting a bit before looking for more jobs");
-        setTimeout(run, 1000*3);
+        setTimeout(run, 1000*1);
     });
 }
 

--- a/handler/start.sh
+++ b/handler/start.sh
@@ -2,7 +2,7 @@
 
 # start server components
 pm2 delete ezbids-handler
-pm2 start handler.js --name ezbids-handler --watch --ignore-watch="*.log test *.sh ui bin example .git .syncthing*"
+pm2 start handler.js --name ezbids-handler --watch --ignore-watch="*.log test *.sh ui bin example .git .syncthing* __pycache__"
 
 pm2 delete ezbids-handler-tsc
 pm2 start tsc.sh --name ezbids-handler-tsc

--- a/launch.sh
+++ b/launch.sh
@@ -67,6 +67,29 @@ else
   mkdir -p ${EZBIDS_TMP_DIR}
 fi
 
+# Ensure proper permissions for Docker access
+# Get the current user's UID and GID
+CURRENT_UID=$(id -u)
+CURRENT_GID=$(id -g)
+
+# Set permissions to allow Docker access
+if ! chmod 770 ${EZBIDS_TMP_DIR} 2>/dev/null; then
+    echo "Warning: Unable to set permissions on ${EZBIDS_TMP_DIR}"
+    echo "You may need to run one of the following commands with sudo:"
+    echo "  sudo chmod 770 ${EZBIDS_TMP_DIR}"
+    echo "  sudo chown ${CURRENT_UID}:${CURRENT_GID} ${EZBIDS_TMP_DIR}"
+    echo "Alternatively, you can set EZBIDS_TMP_DIR in your .env file to a directory you own."
+    exit 1
+fi
+
+if ! chown ${CURRENT_UID}:${CURRENT_GID} ${EZBIDS_TMP_DIR} 2>/dev/null; then
+    echo "Warning: Unable to set ownership on ${EZBIDS_TMP_DIR}"
+    echo "You may need to run:"
+    echo "  sudo chown ${CURRENT_UID}:${CURRENT_GID} ${EZBIDS_TMP_DIR}"
+    echo "Alternatively, you can set EZBIDS_TMP_DIR in your .env file to a directory you own."
+    exit 1
+fi
+
 # ok docker compose is now included in docker as an option for docker
 if [[ $(command -v docker-compose) ]]; then 
     # if the older version is installed use the dash


### PR DESCRIPTION
Docker on Mac was having issues with mounting /tmp/, so update launch.sh to throw a warning if it is unable to mount, create, or own a folder mounted there. Also decreased delay in the handler in looking for new jobs as well as disabled watch for __pycache__ in handler start with PM2. Watch should....be disabled for local deployment and instead a development docker compose should be written, but we're keeping this set of changes to the minimum for now.