### PR TITLE
turn off pet2bids when required

### DIFF
--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -53,6 +53,7 @@ services:
         environment:
             MONGO_CONNECTION_STRING: mongodb://mongodb:27017/ezbids
             PRESORT: ${PRESORT:-false}
+            PET2BIDS_ENABLED: ${PET2BIDS_ENABLED:-true}
         networks:
             - ezbids
         tty: true #turn on color for bids-validator output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
         environment:
             MONGO_CONNECTION_STRING: mongodb://mongodb:27017/ezbids
             PRESORT: ${PRESORT:-false}
+            PET2BIDS_ENABLED: ${PET2BIDS_ENABLED:-true}
         networks:
             - ezbids
         tty: true #turn on color for bids-validator output

--- a/example.env
+++ b/example.env
@@ -3,7 +3,7 @@
 # insert your host name here, it should match your ssl certificate and/or the output
 # of echo $HOSTNAME
 SERVER_NAME=localhost
-PET2BIDS_ENABLED=false
+PET2BIDS_ENABLED=true
 
 # Set the BRAINLIFE_USE_NGINX environment variable to true to use https"
 # (this will launch the services on port 443) and run with nginx/production_nginx.conf"

--- a/example.env
+++ b/example.env
@@ -3,7 +3,7 @@
 # insert your host name here, it should match your ssl certificate and/or the output
 # of echo $HOSTNAME
 SERVER_NAME=localhost
-
+PET2BIDS_ENABLED=false
 
 # Set the BRAINLIFE_USE_NGINX environment variable to true to use https"
 # (this will launch the services on port 443) and run with nginx/production_nginx.conf"

--- a/handler/find_img_data.py
+++ b/handler/find_img_data.py
@@ -8,8 +8,9 @@ from presort_dicoms import presort
 
 # presort can slow down ezBIDS as it examines every dicom, it's enabled/disabled
 # by setting the PRESORT environment variable to "true" or ""
-presort_enabled = bool(os.getenv('PRESORT', 'false').lower() == 'true')
-presort_enabled_pet = bool(os.getenv('PRESORT_PET', 'false').lower() == 'true')
+presort_enabled = bool(os.getenv("PRESORT", "false").lower() == "true")
+presort_enabled_pet = bool(os.getenv("PRESORT_PET", "false").lower() == "true")
+pet2bids_enabled = bool(os.getenv("PET2BIDS_ENABLED", "true").lower() == "true")
 
 
 # if pet2bids is installed we use it wherever the PET data live
@@ -19,12 +20,13 @@ try:
     from pypet2bids import is_pet
 except (ImportError, ModuleNotFoundError):
     pet2bidsInstalled = False
-    print('pet2bids is not installed, using dcm2niix on PET directories instead')
+    print("pet2bids is not installed, using dcm2niix on PET directories instead")
     # Don't exit, just continue without PET support
     is_pet = None
 
+
 def find_img_data(dir):
-    '''
+    """
     Finds all directories that contain DICOM (or other) raw imaging data.
     If dcm2niix output (NIfTI, JSON files) uploaded instead, ezBIDS has separate process for detecting those files.
 
@@ -32,24 +34,26 @@ def find_img_data(dir):
     ----------
     dir : string
         root-level directory of uploaded data
-    '''
+    """
     global mri_dcm_dirs_list
     hasImgData = False
 
     # Define common DICOM file extensions (lowercase)
-    dicom_extensions = ('.dcm', '.ima', '.img', '')
+    dicom_extensions = (".dcm", ".ima", ".img", "")
 
-    with open('find_img_data.log', 'w') as log:
+    with open("find_img_data.log", "w") as log:
         # MRI (raw only)
         for root, dirs, files in os.walk(dir):
             for f in sorted(files):
                 # Case-insensitive extension check
                 if any(f.lower().endswith(ext) for ext in dicom_extensions):
                     try:
-                        log.write(f"Trying to read DICOM file: {os.path.join(root, f)}\n")
+                        log.write(
+                            f"Trying to read DICOM file: {os.path.join(root, f)}\n"
+                        )
                         read_file = dcmread(os.path.join(root, f))
                         log.write(f"DICOM Modality: {read_file.Modality}\n")
-                        if read_file.Modality == 'MR':
+                        if read_file.Modality == "MR":
                             if root not in mri_dcm_dirs_list:
                                 log.write(f"Found MRI directory: {root}\n")
                                 mri_dcm_dirs_list.append(root)
@@ -66,6 +70,7 @@ def find_img_data(dir):
                 if os.path.isdir(full_path):
                     find_img_data(full_path)
 
+
 # change to input directory
 root = sys.argv[1]
 os.chdir(root)
@@ -78,47 +83,70 @@ meg_data_list = []
 root_full_path = str(Path(root).absolute())
 
 # Actually call find_img_data with the root directory
-find_img_data('.')
+find_img_data(".")
 
 # PET
-pet_folders = [str(folder) for folder in is_pet.pet_folder(Path(root).resolve(), skim=True, njobs=4)]
-pet_folders = [os.path.relpath(x, root) for x in pet_folders if x != '']
-pet_folders = [os.path.join('.', x) for x in pet_folders]
+pet_folders = [
+    str(folder)
+    for folder in is_pet.pet_folder(Path(root).resolve(), skim=True, njobs=4)
+]
+pet_folders = [os.path.relpath(x, root) for x in pet_folders if x != ""]
+pet_folders = [os.path.join(".", x) for x in pet_folders]
 
 if pet_folders:
     for pet in pet_folders:
         # See if we're dealing ECAT-formatted file(s)
-        ecats = [x for x in os.listdir(pet) if x.endswith(tuple(['.v', '.v.gz']))]
+        ecats = [x for x in os.listdir(pet) if x.endswith(tuple([".v", ".v.gz"]))]
         if len(ecats):
             for ecat in ecats:
                 if ecat not in pet_ecat_files_list:
-                    pet_ecat_files_list.append(f'{pet}/{ecat}')
+                    pet_ecat_files_list.append(f"{pet}/{ecat}")
         # See if we're dealing with DICOM files
         dcms = [
-            x for x in os.listdir(pet)
-            if not x.endswith(tuple(['.nii', '.nii.gz', '.v', '.v.gz', '.json', '.tsv']))
+            x
+            for x in os.listdir(pet)
+            if not x.endswith(
+                tuple([".nii", ".nii.gz", ".v", ".v.gz", ".json", ".tsv"])
+            )
         ]
         if len(dcms) and pet not in pet_dcm_dirs_list:
             pet_dcm_dirs_list.append(pet)
 
 # MEG
-MEG_extensions = ['*.ds', '*.fif', '*.sqd', '*.con', '*.raw', '*.ave', '*.mrk', '*.kdf', '*.mhd', '*.trg', '*.chn', '*.dat']
+MEG_extensions = [
+    "*.ds",
+    "*.fif",
+    "*.sqd",
+    "*.con",
+    "*.raw",
+    "*.ave",
+    "*.mrk",
+    "*.kdf",
+    "*.mhd",
+    "*.trg",
+    "*.chn",
+    "*.dat",
+]
 for meg_ext in MEG_extensions:
-    if meg_ext == '*.ds':
-        type_search = 'd'
+    if meg_ext == "*.ds":
+        type_search = "d"
     else:
-        type_search = 'f'
+        type_search = "f"
 
-    find_cmd = os.popen(f"find . -maxdepth 9 -type {type_search} -name '{meg_ext}'").read()
-    if find_cmd != '':
+    find_cmd = os.popen(
+        f"find . -maxdepth 9 -type {type_search} -name '{meg_ext}'"
+    ).read()
+    if find_cmd != "":
         meg_data_list.append(find_cmd)
 
 if len(meg_data_list):
     # TODO - won't this remove different extensions?
-    meg_data_list = [x for x in meg_data_list[0].split('\n') if x != '' and 'hz.ds' not in x]
+    meg_data_list = [
+        x for x in meg_data_list[0].split("\n") if x != "" and "hz.ds" not in x
+    ]
 
 # Save the MRI, PET, MEG, and NIfTI lists (if they exist) to separate files
-file = open(f'{root}/dcm2niix.list', 'w')
+file = open(f"{root}/dcm2niix.list", "w")
 if len(mri_dcm_dirs_list):
     # Sort the list before writing
     sorted_mri_dirs = sorted(mri_dcm_dirs_list)
@@ -126,32 +154,44 @@ if len(mri_dcm_dirs_list):
         if presort_enabled:
             presorted_dicoms = sorted(presort(dcm))  # Sort presorted results too
             for pre in presorted_dicoms:
-                file.write(str(pre) + '\n')
+                file.write(str(pre) + "\n")
         else:
-            file.write(dcm + '\n')
-file.close()
+            file.write(dcm + "\n")
 
-if len(pet_dcm_dirs_list):
-    file = open(f'{root}/pet2bids_dcm.list', 'w')
+# Add PET directories to dcm2niix.list when pet2bids is disabled
+if len(pet_dcm_dirs_list) and not pet2bids_enabled:
     # Sort the list before writing
     sorted_pet_dirs = sorted(pet_dcm_dirs_list)
     for dcm in sorted_pet_dirs:
         if presort_enabled:
             presorted_folders = sorted(presort(dcm))  # Sort presorted results too
             for pre in presorted_folders:
-                file.write(str(pre) + '\n')
+                file.write(str(pre) + "\n")
         else:
-            file.write(dcm + '\n')
+            file.write(dcm + "\n")
+file.close()
+
+if len(pet_dcm_dirs_list) and pet2bids_enabled:
+    file = open(f"{root}/pet2bids_dcm.list", "w")
+    # Sort the list before writing
+    sorted_pet_dirs = sorted(pet_dcm_dirs_list)
+    for dcm in sorted_pet_dirs:
+        if presort_enabled:
+            presorted_folders = sorted(presort(dcm))  # Sort presorted results too
+            for pre in presorted_folders:
+                file.write(str(pre) + "\n")
+        else:
+            file.write(dcm + "\n")
     file.close()
 
-if len(pet_ecat_files_list):
-    file = open(f'{root}/pet2bids_ecat.list', 'w')
+if len(pet_ecat_files_list) and pet2bids_enabled:
+    file = open(f"{root}/pet2bids_ecat.list", "w")
     for ecat in pet_ecat_files_list:
-        file.write(ecat + '\n')
+        file.write(ecat + "\n")
     file.close()
 
 if len(meg_data_list):
-    file = open(f'{root}/meg.list', 'w')
+    file = open(f"{root}/meg.list", "w")
     for meg in meg_data_list:
-        file.write(meg + '\n')
+        file.write(meg + "\n")
     file.close()


### PR DESCRIPTION
This PR toggles PET2BIDS off if you don't want to use it via the PET2BIDS_ENABLED environment variable, this variable can be set in either the .env file or locally in the same environment docker compose / `launch.sh` is run from.